### PR TITLE
Potential fix for code scanning alert no. 7: Incomplete multi-character sanitization

### DIFF
--- a/src/cli/tools/read-file-tool.ts
+++ b/src/cli/tools/read-file-tool.ts
@@ -208,8 +208,12 @@ export class ReadFileTool extends BaseTool {
                 break;
             case '.html':
             case '.xml':
-                // Remove HTML/XML comments
-                content = content.replace(/<!--[\s\S]*?-->/g, '');
+                // Remove HTML/XML comments (apply repeatedly to ensure complete removal)
+                let previousContent;
+                do {
+                    previousContent = content;
+                    content = content.replace(/<!--[\s\S]*?-->/g, '');
+                } while (content !== previousContent);
                 break;
         }
 


### PR DESCRIPTION
Potential fix for [https://github.com/nikomatt69/agent-cli/security/code-scanning/7](https://github.com/nikomatt69/agent-cli/security/code-scanning/7)

To fix the incomplete multi-character sanitization, we should ensure that all instances of HTML/XML comments are fully removed, even if new instances are exposed after a replacement. The best way to do this without changing existing functionality is to repeatedly apply the replacement until no more matches are found. This can be done by looping until the content no longer changes after a replacement. The change should be made only in the `.html` and `.xml` case of the `stripComments` method, specifically replacing line 212. No new imports or dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
