### PR TITLE
Potential fix for code scanning alert no. 6: Incomplete multi-character sanitization

### DIFF
--- a/src/cli/core/documentation-library.ts
+++ b/src/cli/core/documentation-library.ts
@@ -194,9 +194,19 @@ export class DocumentationLibrary {
    */
   private extractTextFromHTML(html: string): string {
     // Rimuovi tag HTML
-    let text = html
-      .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '')
-      .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '')
+    let text = html;
+    // Rimuovi tutti i blocchi <script>...</script> in modo sicuro
+    let prev;
+    do {
+      prev = text;
+      text = text.replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '');
+    } while (text !== prev);
+    // Rimuovi tutti i blocchi <style>...</style> in modo sicuro
+    do {
+      prev = text;
+      text = text.replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '');
+    } while (text !== prev);
+    text = text
       .replace(/<[^>]+>/g, ' ')
       .replace(/&nbsp;/g, ' ')
       .replace(/&amp;/g, '&')


### PR DESCRIPTION
Potential fix for [https://github.com/nikomatt69/agent-cli/security/code-scanning/6](https://github.com/nikomatt69/agent-cli/security/code-scanning/6)

To fix the incomplete multi-character sanitization, we should ensure that all `<script>...</script>` and `<style>...</style>` blocks are fully removed, even if they are nested, malformed, or repeated in a way that a single `.replace()` call would miss. The best way to do this, without changing existing functionality, is to repeatedly apply the regex replacement in a loop until no more matches are found. This ensures that all instances are removed, regardless of how they are arranged in the input. The same approach should be applied to both `<script>` and `<style>` tag removal. No new imports are needed, and the change is limited to the `extractTextFromHTML` method in `src/cli/core/documentation-library.ts`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
