### PR TITLE
Potential fix for code scanning alert no. 9: Clear-text logging of sensitive information

### DIFF
--- a/src/cli/nik-cli.ts
+++ b/src/cli/nik-cli.ts
@@ -3960,7 +3960,7 @@ Planning:
                     // Test API key
                     const apiKey = configManager.getApiKey(currentModel);
                     if (apiKey) {
-                        console.log(chalk.green(`✅ API Key: ${apiKey.slice(0, 10)}...${apiKey.slice(-4)} (${apiKey.length} chars)`));
+                        console.log(chalk.green(`✅ API Key: Configured (${apiKey.length} chars)`));
                     } else {
                         console.log(chalk.red(`❌ API Key: Not configured`));
                     }


### PR DESCRIPTION
Potential fix for [https://github.com/nikomatt69/agent-cli/security/code-scanning/9](https://github.com/nikomatt69/agent-cli/security/code-scanning/9)

To fix the problem, we should avoid logging any part of the API key, even in debug output. Instead, we can indicate whether an API key is configured and, optionally, display its length (which is not sensitive), but not any part of the key itself. The fix should be applied to the block handling the 'debug' command, specifically line 3963 in `src/cli/nik-cli.ts`. No new methods or imports are needed; simply change the log statement to avoid exposing the API key.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
